### PR TITLE
Repair Compatibility issue with Rollup Bundler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "module": "dist/gpt3-tokenizer.esm.js",
+  "module": "dist/gpt3-tokenizer.cjs.production.min.js",
   "size-limit": [
     {
       "path": "dist-browser/gpt3-tokenizer.js",


### PR DESCRIPTION
The Rollup Bundler requires a path to an existing module file. 

Otherwise you encounter the following error:
```
[commonjs--resolver] Failed to resolve entry for package "gpt3-tokenizer". The package may have incorrect main/module/exports specified in its package.json.
error during build:
Error: Failed to resolve entry for package "gpt3-tokenizer". The package may have incorrect main/module/exports specified in its package.json.
    at packageEntryFailure (/node_modules/vite/dist/node/chunks/dep-1513d487.js:34405:11)
    at resolvePackageEntry (/node_modules/vite/dist/node/chunks/dep-1513d487.js:34402:5)
    at tryNodeResolve (/node_modules/vite/dist/node/chunks/dep-1513d487.js:34160:20)
    at Object.resolveId (node_modules/vite/dist/node/chunks/dep-1513d487.js:33962:28)
    at /node_modules/rollup/dist/es/shared/rollup.js:22694:37
```