### PR TITLE
Fix encoding strings containing js object inherited properties

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -130,7 +130,7 @@ export default abstract class GPT3Tokenizer {
   }
 
   bpe(token: string) {
-    if (token in this.cache) {
+    if (this.cache.hasOwnProperty(token)) {
       return this.cache[token];
     }
 

--- a/test/tokenizer.test.ts
+++ b/test/tokenizer.test.ts
@@ -57,4 +57,12 @@ describe('gpt3 tokenizer test', () => {
     expect(encoded.bpe).toEqual([4299, 1388, 33529, 198, 50258, 3601, 10786, 31373, 995, 11537]);
     expect(tokenizer.decode(encoded.bpe)).toEqual(str);
   });
+
+  it('works with javascript object property strings', () => {
+    const tokenizer = new GPT3Tokenizer({ type: 'codex' });
+    const str = 'some_code toString some_more_code';
+    const encoded = tokenizer.encode(str);
+    expect(encoded.bpe).toEqual([11246, 62, 8189, 284, 10100, 617, 62, 3549, 62, 8189]);
+    expect(tokenizer.decode(encoded.bpe)).toEqual(str);
+  });
 });


### PR DESCRIPTION
Hi @lhr0909, 

I found a minor bug that causes the `tokenizer.encode()` to fail if you pass in code that contains strings that are equal to the inherited properties of javascript objects. 

See the included test for one example where the string `toString` causes problem:
```javascript
it('works with javascript object property strings', () => {
    const tokenizer = new GPT3Tokenizer({ type: 'codex' });
    const str = 'some_code toString some_more_code';
    const encoded = tokenizer.encode(str);
    expect(encoded.bpe).toEqual([11246, 62, 8189, 284, 10100, 617, 62, 3549, 62, 8189]);
    expect(tokenizer.decode(encoded.bpe)).toEqual(str);
  });
```

Example error:
```
TypeError: this.bpe(...).split is not a function
at GPT3NodeTokenizer.encode (gpt3-tokenizer/dist/gpt3-tokenizer.cjs.development.js:190:41)
```
Please let me know if I need to adapt anything with the PR.

Thank you
✌🏻 Adam